### PR TITLE
Add helpful message for unknown actions

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -37,5 +37,5 @@ func (p *Plugin) disconnectCommandFunc(args *model.CommandArgs) (*model.CommandR
 			&model.AppError{Message: err.Error()}
 	}
 
-	return p.responsef(args, "Successfully disconnected token: %s", ), nil
+	return p.responsef(args, "Successfully disconnected token"), nil
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -29,3 +29,13 @@ func (p *Plugin) connectCommandFunc(args *model.CommandArgs) (*model.CommandResp
 
 	return p.responsef(args, "Successfully added a connecting token"), nil
 }
+
+func (p *Plugin) disconnectCommandFunc(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	err := p.store.DeleteUserDOToken(args.UserId)
+	if err != nil {
+		return p.responsef(args, "Failed to remove the user token"),
+			&model.AppError{Message: err.Error()}
+	}
+
+	return p.responsef(args, "Successfully disconnected token: %s", ), nil
+}

--- a/server/command.go
+++ b/server/command.go
@@ -27,6 +27,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		return p.helpCommandFunc(args)
 	case "connect":
 		return p.connectCommandFunc(args)
+	case "disconnect":
+		return p.disconnectCommandFunc(args)
 	case "token":
 		return p.getPersonalTokenCommandFunc(args)
 	case "show-configured-token":

--- a/server/command.go
+++ b/server/command.go
@@ -36,7 +36,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	case "list-droplets":
 		return p.listDropletsFunc(args)
 	default:
-		return p.responsef(args, fmt.Sprintf("Unknown action %v", action)), nil
+		return p.defaultCommandFunc(args, action)
 	}
 }
 

--- a/server/help.go
+++ b/server/help.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"strings"
 )
 
-const commandHelp = `* |/do help| - Run 'test' to see if you're configured to run bamboo commands
+const commandHelp = `* |/do help| - Run 'test' to see if you're configured to run do commands
 * |/do connect <access token>| - Associates your DO team personal token with your mattermost account
 * |/do disconnect| - Remove your DO team personal token with your mattermost account
 * |/do token| - Provides instructions on getting a personal access token for the configured DigitalOcean team
@@ -15,5 +16,10 @@ const commandHelp = `* |/do help| - Run 'test' to see if you're configured to ru
 
 func (p *Plugin) helpCommandFunc(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	text := "###### Mattermost DigitalOcean Plugin - Slash Command Help\n" + strings.Replace(commandHelp, "|", "`", -1)
+	return p.responsef(args, text), nil
+}
+
+func (p *Plugin) defaultCommandFunc(args *model.CommandArgs, action string) (*model.CommandResponse, *model.AppError) {
+	text := fmt.Sprintf("Unknown action %s. The following commands might help\n", action) + strings.Replace(commandHelp, "|", "`", -1)
 	return p.responsef(args, text), nil
 }

--- a/server/help.go
+++ b/server/help.go
@@ -7,6 +7,7 @@ import (
 
 const commandHelp = `* |/do help| - Run 'test' to see if you're configured to run bamboo commands
 * |/do connect <access token>| - Associates your DO team personal token with your mattermost account
+* |/do disconnect| - Remove your DO team personal token with your mattermost account
 * |/do token| - Provides instructions on getting a personal access token for the configured DigitalOcean team
 * |/do show-configured-token| - Display your configured access token
 * |/do list-droplets| - List all Droplets in your team

--- a/server/store.go
+++ b/server/store.go
@@ -4,6 +4,7 @@ package main
 type Store interface {
 	StoreUserDOToken(token string, key string) error
 	LoadUserDOToken(key string) (string, error)
+	DeleteUserDOToken(key string) error
 }
 
 // PluginStore is
@@ -36,4 +37,13 @@ func (s *PluginStore) LoadUserDOToken(key string) (string, error) {
 	}
 
 	return string(data), nil
+}
+
+// DeleteUserDOToken is
+func (s *PluginStore) DeleteUserDOToken(key string) error {
+	apiErr := s.plugin.API.KVDelete(key)
+	if apiErr != nil {
+		return apiErr
+	}
+	return nil
 }


### PR DESCRIPTION
In case a user types a command against do e.g` /do unknown`, they should receive a response with the help message.

<img width="1031" alt="Screenshot 2020-02-14 at 17 03 12" src="https://user-images.githubusercontent.com/13383422/74537991-34ca3f80-4f4c-11ea-8f7c-bdda081285f4.png">

fixes #10 