### PR TITLE
Add webpack external for ReactDOM

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = {
     },
     externals: {
         react: 'React',
+        'react-dom': 'ReactDOM',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',


### PR DESCRIPTION
This PR makes it so the webapp portion of this plugin uses the same version/instance of ReactDOM as the webapp itself. Some more context here https://github.com/mattermost/mattermost-plugin-starter-template/pull/169

Fixes https://github.com/phillipahereza/mattermost-plugin-digitalocean/issues/75